### PR TITLE
Fix #11 - map missing

### DIFF
--- a/src/react/components/transport/index.jsx
+++ b/src/react/components/transport/index.jsx
@@ -3,11 +3,15 @@ import loadOSM from './openstreetmap.js'
 
 export default class extends Component {
 	componentDidMount() {
-		setTimeout(loadOSM, 3000)
+		this.setState({osmMap: loadOSM()})
 	}
 
 	shouldComponentUpdate(nextProps, nextState) {
 		return this.props.active !== nextProps.active
+	}
+
+	componentDidUpdate(prevProps, prevState) {
+		this.state.osmMap.updateSize()
 	}
 
 	render() {

--- a/src/react/components/transport/openstreetmap.js
+++ b/src/react/components/transport/openstreetmap.js
@@ -37,4 +37,5 @@ export default function() {
 			zoom: 15
 		})
 	})
+	return osmMap
 }


### PR DESCRIPTION
因為 React Lifecycle 特性，在尚未切換到交通分頁時，地圖已被呼叫載入，但此時 map component 之 size 為 0 x 0。
修正方法為，在交通分頁顯示時，呼叫 updateSize() 重新繪製 map。